### PR TITLE
Add AWS cost allocation tags

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -1,6 +1,7 @@
 resource "aws_apigatewayv2_api" "http_api" {
   name          = "sensing-garden-api"
   protocol_type = "HTTP"
+  tags          = local.api_http_tags
 
   cors_configuration {
     allow_headers = ["Content-Type", "X-Amz-Date", "Authorization", "X-Api-Key"]
@@ -22,6 +23,7 @@ resource "aws_api_gateway_api_key" "test_key" {
   name        = "sensing-garden-api-key-test"
   enabled     = true
   description = "API key for test environment"
+  tags        = local.api_key_test_tags
 }
 
 # Edge/production environment API key (existing: y90f3ne7m7)
@@ -29,6 +31,7 @@ resource "aws_api_gateway_api_key" "edge_key" {
   name        = "sensing-garden-api-key-edge"
   enabled     = true
   description = "API key for edge/production environment"
+  tags        = local.api_key_edge_tags
 }
 
 # Frontend API key (existing: 2xapcek3tc)
@@ -36,6 +39,7 @@ resource "aws_api_gateway_api_key" "frontend_key" {
   name        = "sensing-garden-api-key-frontend"
   enabled     = true
   description = "API key for frontend environment"
+  tags        = local.dashboard_api_auth_tags
 }
 
 # Deployments dashboard API key
@@ -44,12 +48,15 @@ resource "aws_api_gateway_api_key" "deployments_key" {
   enabled     = true
   description = "API key for deployments dashboard access"
   value       = var.deployments_api_key_value
+  tags        = local.dashboard_api_auth_tags
 }
 
 resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.http_api.id
   name        = "$default"
   auto_deploy = true
+  tags        = local.api_http_tags
+
   default_route_settings {
     throttling_rate_limit  = 100
     throttling_burst_limit = 100
@@ -71,6 +78,7 @@ resource "aws_apigatewayv2_integration" "api_lambda" {
 resource "aws_api_gateway_usage_plan" "usage_plan" {
   name        = "sensing-garden-usage-plan"
   description = "Standard usage plan for API"
+  tags        = local.api_http_tags
 
   # Note: HTTP APIs don't directly integrate with usage plans in the same way as REST APIs
   # This is a limitation of the current AWS API Gateway implementation

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -4,6 +4,7 @@
 
 resource "aws_route53_zone" "main" {
   name = "sensinggarden.com"
+  tags = local.platform_dns_tags
 }
 
 resource "aws_route53_record" "api" {

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -4,6 +4,7 @@ resource "aws_dynamodb_table" "sensor_detections" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "device_id"
   range_key    = "timestamp"
+  tags         = local.observation_detections_tags
 
   attribute {
     name = "device_id"
@@ -29,7 +30,11 @@ resource "aws_dynamodb_table" "sensor_detections" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = all
+    ignore_changes = [
+      deletion_protection_enabled,
+      read_capacity,
+      write_capacity,
+    ]
   }
 }
 
@@ -38,6 +43,7 @@ resource "aws_dynamodb_table" "devices" {
   name         = "sensing-garden-devices"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "device_id"
+  tags         = local.device_registry_tags
 
   attribute {
     name = "device_id"
@@ -47,7 +53,11 @@ resource "aws_dynamodb_table" "devices" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = all
+    ignore_changes = [
+      deletion_protection_enabled,
+      read_capacity,
+      write_capacity,
+    ]
   }
 }
 
@@ -57,6 +67,7 @@ resource "aws_dynamodb_table" "sensor_classifications" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "device_id"
   range_key    = "timestamp"
+  tags         = local.observation_classifications_tags
 
   attribute {
     name = "device_id"
@@ -112,7 +123,6 @@ resource "aws_dynamodb_table" "sensor_classifications" {
       billing_mode,
       read_capacity,
       write_capacity,
-      tags,
     ]
   }
 }
@@ -123,6 +133,7 @@ resource "aws_dynamodb_table" "models" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "id"
   range_key    = "timestamp"
+  tags         = local.model_metadata_tags
 
   attribute {
     name = "id"
@@ -148,7 +159,11 @@ resource "aws_dynamodb_table" "models" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = all
+    ignore_changes = [
+      deletion_protection_enabled,
+      read_capacity,
+      write_capacity,
+    ]
   }
 }
 
@@ -158,6 +173,7 @@ resource "aws_dynamodb_table" "videos" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "device_id"
   range_key    = "timestamp"
+  tags         = local.media_video_index_tags
 
   attribute {
     name = "device_id"
@@ -183,7 +199,11 @@ resource "aws_dynamodb_table" "videos" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = all
+    ignore_changes = [
+      deletion_protection_enabled,
+      read_capacity,
+      write_capacity,
+    ]
     # This will prevent Terraform from trying to recreate the table if it already exists
     create_before_destroy = true
   }
@@ -195,6 +215,7 @@ resource "aws_dynamodb_table" "environmental_readings" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "device_id"
   range_key    = "timestamp"
+  tags         = local.observation_environment_tags
 
   attribute {
     name = "device_id"
@@ -210,7 +231,10 @@ resource "aws_dynamodb_table" "environmental_readings" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = all
+    ignore_changes = [
+      read_capacity,
+      write_capacity,
+    ]
   }
 }
 
@@ -219,6 +243,7 @@ resource "aws_dynamodb_table" "deployments" {
   name         = "sensing-garden-deployments"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "deployment_id"
+  tags         = local.deployment_registry_tags
 
   attribute {
     name = "deployment_id"
@@ -227,7 +252,10 @@ resource "aws_dynamodb_table" "deployments" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = all
+    ignore_changes = [
+      read_capacity,
+      write_capacity,
+    ]
   }
 }
 
@@ -237,6 +265,7 @@ resource "aws_dynamodb_table" "deployment_device_connections" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "deployment_id"
   range_key    = "device_id"
+  tags         = local.deployment_registry_tags
 
   attribute {
     name = "deployment_id"
@@ -250,7 +279,10 @@ resource "aws_dynamodb_table" "deployment_device_connections" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = all
+    ignore_changes = [
+      read_capacity,
+      write_capacity,
+    ]
   }
 }
 
@@ -260,6 +292,7 @@ resource "aws_dynamodb_table" "tracks" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "track_id"
   range_key    = "device_id"
+  tags         = local.observation_tracks_tags
 
   attribute {
     name = "track_id"
@@ -296,6 +329,7 @@ resource "aws_dynamodb_table" "heartbeats" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "device_id"
   range_key    = "timestamp"
+  tags         = local.device_heartbeats_tags
 
   attribute {
     name = "device_id"
@@ -318,6 +352,7 @@ resource "aws_dynamodb_table" "device_api_keys" {
   name         = "sensing-garden-device-api-keys"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "device_id"
+  tags         = local.device_auth_tags
 
   attribute {
     name = "device_id"
@@ -347,6 +382,7 @@ resource "aws_dynamodb_table" "activity_events" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "event_date"
   range_key    = "timestamp_event_id"
+  tags         = local.dashboard_audit_tags
 
   attribute {
     name = "event_date"
@@ -374,6 +410,7 @@ resource "aws_dynamodb_table" "processed_objects" {
   name         = "sensing-garden-s3-processed-objects"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "object_id"
+  tags         = local.pipeline_dedupe_tags
 
   attribute {
     name = "object_id"

--- a/terraform/elastic_beanstalk.tf
+++ b/terraform/elastic_beanstalk.tf
@@ -20,6 +20,7 @@ variable "dashboard_secret_key" {
 
 resource "aws_s3_bucket" "web_deploy" {
   bucket = "scl-sensing-garden-web-deploy"
+  tags   = local.dashboard_deploy_tags
 }
 
 resource "aws_s3_bucket_public_access_block" "web_deploy" {
@@ -37,6 +38,7 @@ resource "aws_s3_bucket_public_access_block" "web_deploy" {
 
 resource "aws_iam_role" "eb_ec2_role" {
   name = "eb-sensing-garden-web-role"
+  tags = local.dashboard_web_tags
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -140,6 +142,7 @@ resource "aws_iam_instance_profile" "eb_ec2_profile" {
 
 resource "aws_iam_role" "eb_service_role" {
   name = "eb-sensing-garden-web-service-role"
+  tags = local.dashboard_web_tags
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -171,6 +174,7 @@ resource "aws_iam_role_policy_attachment" "eb_managed_updates" {
 
 resource "aws_elastic_beanstalk_application" "web" {
   name = "sensing-garden-web"
+  tags = local.dashboard_web_tags
 }
 
 # =============================================================================
@@ -181,6 +185,7 @@ resource "aws_elastic_beanstalk_environment" "web" {
   name                = "sensing-garden-web-prod"
   application         = aws_elastic_beanstalk_application.web.name
   solution_stack_name = "64bit Amazon Linux 2023 v4.12.0 running Python 3.11"
+  tags                = local.dashboard_web_tags
 
   setting {
     namespace = "aws:elasticbeanstalk:environment"
@@ -265,6 +270,7 @@ resource "aws_cloudfront_distribution" "web" {
   comment         = "Sensing Garden Dashboard"
   price_class     = "PriceClass_100"
   is_ipv6_enabled = true
+  tags            = local.dashboard_web_tags
 
   origin {
     domain_name = aws_elastic_beanstalk_environment.web.cname

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -4,6 +4,8 @@
 # Lambda execution role
 resource "aws_iam_role" "lambda_exec" {
   name = "lambda_exec_role"
+  tags = local.api_handler_tags
+
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "api_handler_function" {
   source_code_hash = filebase64sha256("${path.module}/../lambda/deployment_package.zip")
   timeout          = 30  # Longer timeout for pagination and processing
   memory_size      = 256 # Increased memory for better performance
+  tags             = local.api_handler_tags
 
   environment {
     variables = {
@@ -61,6 +62,8 @@ resource "aws_lambda_permission" "api_gateway_api_handler" {
 # IAM role for trigger Lambda
 resource "aws_iam_role" "trigger_lambda_exec" {
   name = "trigger_lambda_exec_role"
+  tags = local.pipeline_processor_tags
+
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -172,6 +175,7 @@ resource "aws_lambda_function" "trigger_handler_function" {
   source_code_hash = filebase64sha256("${path.module}/../trigger/deployment_package.zip")
   timeout          = 300
   memory_size      = 512
+  tags             = local.pipeline_processor_tags
 
   environment {
     variables = {

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -13,4 +13,8 @@ terraform {
 
 provider "aws" {
   region = "us-east-1"
+
+  default_tags {
+    tags = local.common_tags
+  }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,6 +1,7 @@
 # Create S3 bucket for images
 resource "aws_s3_bucket" "sensor_images" {
   bucket = "scl-sensing-garden-images"
+  tags   = local.media_images_tags
 
   lifecycle {
     prevent_destroy = true
@@ -32,6 +33,7 @@ resource "aws_s3_bucket_cors_configuration" "sensor_images" {
 # Create S3 bucket for videos
 resource "aws_s3_bucket" "sensor_videos" {
   bucket = "scl-sensing-garden-videos"
+  tags   = local.media_videos_tags
 
   lifecycle {
     prevent_destroy = true
@@ -67,6 +69,7 @@ resource "aws_s3_bucket_cors_configuration" "sensor_videos" {
 # Create S3 bucket for ML models (public read)
 resource "aws_s3_bucket" "models" {
   bucket = "scl-sensing-garden-models"
+  tags   = local.model_artifacts_tags
 
   lifecycle {
     prevent_destroy = true
@@ -130,6 +133,7 @@ resource "aws_s3_bucket_cors_configuration" "models" {
 # Create S3 bucket for pipeline output
 resource "aws_s3_bucket" "output" {
   bucket = "scl-sensing-garden"
+  tags   = local.pipeline_output_tags
 }
 
 # Configure public access settings for output bucket (private)

--- a/terraform/tags.tf
+++ b/terraform/tags.tf
@@ -1,0 +1,133 @@
+locals {
+  common_tags = {
+    Project     = "sensing-garden"
+    Environment = "prod"
+    ManagedBy   = "terraform"
+    Repository  = "sensing-garden-backend"
+  }
+
+  api_handler_tags = {
+    CostDomain    = "api"
+    CostComponent = "api-handler"
+  }
+
+  api_http_tags = {
+    CostDomain    = "api"
+    CostComponent = "http-api"
+  }
+
+  api_key_edge_tags = {
+    CostDomain    = "api"
+    CostComponent = "edge-client-auth"
+  }
+
+  api_key_test_tags = {
+    CostDomain    = "api"
+    CostComponent = "test-client-auth"
+  }
+
+  dashboard_api_auth_tags = {
+    CostDomain    = "dashboard"
+    CostComponent = "dashboard-api-auth"
+  }
+
+  dashboard_audit_tags = {
+    CostDomain    = "dashboard"
+    CostComponent = "audit-events"
+  }
+
+  dashboard_deploy_tags = {
+    CostDomain    = "dashboard"
+    CostComponent = "web-deploy"
+  }
+
+  dashboard_web_tags = {
+    CostDomain    = "dashboard"
+    CostComponent = "web-app"
+  }
+
+  deployment_registry_tags = {
+    CostDomain    = "deployment-management"
+    CostComponent = "deployments"
+  }
+
+  device_auth_tags = {
+    CostDomain    = "fleet"
+    CostComponent = "device-auth"
+  }
+
+  device_heartbeats_tags = {
+    CostDomain    = "fleet"
+    CostComponent = "heartbeats"
+  }
+
+  device_registry_tags = {
+    CostDomain    = "fleet"
+    CostComponent = "devices"
+  }
+
+  media_images_tags = {
+    CostDomain    = "media"
+    CostComponent = "images"
+  }
+
+  media_video_index_tags = {
+    CostDomain    = "media"
+    CostComponent = "video-index"
+  }
+
+  media_videos_tags = {
+    CostDomain    = "media"
+    CostComponent = "videos"
+  }
+
+  model_artifacts_tags = {
+    CostDomain    = "models"
+    CostComponent = "model-artifacts"
+  }
+
+  model_metadata_tags = {
+    CostDomain    = "models"
+    CostComponent = "model-metadata"
+  }
+
+  observation_classifications_tags = {
+    CostDomain    = "observations"
+    CostComponent = "classifications"
+  }
+
+  observation_detections_tags = {
+    CostDomain    = "observations"
+    CostComponent = "detections"
+  }
+
+  observation_environment_tags = {
+    CostDomain    = "observations"
+    CostComponent = "environmental-readings"
+  }
+
+  observation_tracks_tags = {
+    CostDomain    = "observations"
+    CostComponent = "tracks"
+  }
+
+  pipeline_dedupe_tags = {
+    CostDomain    = "pipeline"
+    CostComponent = "dedupe"
+  }
+
+  pipeline_output_tags = {
+    CostDomain    = "pipeline"
+    CostComponent = "pipeline-output"
+  }
+
+  pipeline_processor_tags = {
+    CostDomain    = "pipeline"
+    CostComponent = "output-processor"
+  }
+
+  platform_dns_tags = {
+    CostDomain    = "platform"
+    CostComponent = "dns"
+  }
+}


### PR DESCRIPTION
Adds AWS cost allocation tags to the Sensing Garden Terraform resources.

To view costs after activating the tags in the AWS Billing portal:
1. AWS Billing → Cost allocation tags: activate `Project`, `Environment`, and `CostDomain`.
2. Wait for billing data to populate.
3. Cost Explorer: filter `Project = sensing-garden`, then group by `CostDomain`.

Optional drilldown: activate/group by `CostComponent` if more detail is needed.
