### PR TITLE
Feat/archive and multipart

### DIFF
--- a/lambda/src/auth.py
+++ b/lambda/src/auth.py
@@ -66,6 +66,10 @@ DEPLOYMENTS_ALLOWED_WRITE_PATTERNS = (
 
 DEVICE_ALLOWED_ROUTES = (
     ("POST", "/upload-url"),
+    ("POST", "/multipart/create"),
+    ("POST", "/multipart/part-url"),
+    ("POST", "/multipart/complete"),
+    ("POST", "/multipart/abort"),
     ("GET", "/models"),
 )
 

--- a/lambda/src/handler.py
+++ b/lambda/src/handler.py
@@ -13,6 +13,7 @@ from routes import (
     export,
     heartbeats,
     models,
+    multipart,
     registration,
     tracks,
     uploads,
@@ -38,6 +39,10 @@ ROUTES: Dict[Tuple[str, str], RouteHandler] = {
     ("GET", "/models"): models.handle_get,
     ("GET", "/models/count"): models.handle_get_count,
     ("POST", "/upload-url"): uploads.handle_upload_url,
+    ("POST", "/multipart/create"): multipart.handle_multipart_create,
+    ("POST", "/multipart/part-url"): multipart.handle_multipart_part_url,
+    ("POST", "/multipart/complete"): multipart.handle_multipart_complete,
+    ("POST", "/multipart/abort"): multipart.handle_multipart_abort,
     ("GET", "/videos"): videos.handle_get,
     ("GET", "/videos/count"): videos.handle_get_count,
     ("GET", "/environment"): environment.handle_get,
@@ -83,13 +88,23 @@ def _resolve_http_request(event: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
+# Handlers that act on behalf of an authenticated device (scoped to its keys).
+_DEVICE_SCOPED_HANDLERS = frozenset({
+    uploads.handle_upload_url,
+    multipart.handle_multipart_create,
+    multipart.handle_multipart_part_url,
+    multipart.handle_multipart_complete,
+    multipart.handle_multipart_abort,
+})
+
+
 def _invoke_route(
     route_handler: RouteHandler,
     event: Dict[str, Any],
     auth_context: AuthContext,
     **path_params: str,
 ) -> Dict[str, Any]:
-    if route_handler is uploads.handle_upload_url:
+    if route_handler in _DEVICE_SCOPED_HANDLERS:
         return route_handler(event, authenticated_device=auth_context.get("device_record"))
     if path_params:
         return route_handler(event, **path_params)

--- a/lambda/src/routes/multipart.py
+++ b/lambda/src/routes/multipart.py
@@ -1,0 +1,124 @@
+"""Presigned multipart upload endpoints for large device uploads (e.g. hourly
+batch tars). The device has no AWS credentials, so the backend drives the
+multipart lifecycle: create the upload, hand back a presigned URL per part, then
+complete (or abort). Keys are validated and device-scoped exactly like /upload-url
+(so v1/ and v2/archives/<device>/ are accepted).
+"""
+from typing import Any, Dict
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from routes.uploads import _validate_device_scope, _validate_s3_key
+from s3 import OUTPUT_BUCKET, PRESIGNED_URL_EXPIRY
+from utils import _parse_request, json_response
+
+# S3 error codes that mean the multipart upload no longer exists; surfaced as 404
+# so the device drops its stale upload id and restarts.
+_GONE_CODES = {"NoSuchUpload", "NoSuchKey"}
+
+
+def _client():
+    # SigV4 so presigned upload_part URLs validate everywhere (matches s3.py).
+    return boto3.client("s3", config=Config(signature_version="s3v4"))
+
+
+def _scoped_key(event: Dict[str, Any], authenticated_device: Dict[str, Any] | None):
+    if not authenticated_device:
+        raise PermissionError("Authenticated device context is required")
+    body = _parse_request(event)
+    s3_key = _validate_s3_key(body.get("s3_key"))
+    _validate_device_scope(s3_key, authenticated_device)
+    return body, s3_key
+
+
+def _require(body: Dict[str, Any], name: str) -> Any:
+    value = body.get(name)
+    if value in (None, ""):
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def _gone_or_500(exc: ClientError) -> Dict[str, Any]:
+    if exc.response.get("Error", {}).get("Code") in _GONE_CODES:
+        return json_response(404, {"error": "multipart upload gone"})
+    return json_response(500, {"error": str(exc)})
+
+
+def handle_multipart_create(event, authenticated_device=None):
+    try:
+        _, s3_key = _scoped_key(event, authenticated_device)
+        resp = _client().create_multipart_upload(Bucket=OUTPUT_BUCKET, Key=s3_key)
+        return json_response(200, {"upload_id": resp["UploadId"], "s3_key": s3_key})
+    except ValueError as exc:
+        return json_response(400, {"error": str(exc)})
+    except PermissionError as exc:
+        return json_response(403, {"error": str(exc)})
+    except Exception as exc:  # noqa: BLE001
+        return json_response(500, {"error": str(exc)})
+
+
+def handle_multipart_part_url(event, authenticated_device=None):
+    try:
+        body, s3_key = _scoped_key(event, authenticated_device)
+        upload_id = _require(body, "upload_id")
+        try:
+            part_number = int(_require(body, "part_number"))
+        except (TypeError, ValueError):
+            raise ValueError("part_number must be an integer")
+        url = _client().generate_presigned_url(
+            "upload_part",
+            Params={"Bucket": OUTPUT_BUCKET, "Key": s3_key, "UploadId": upload_id, "PartNumber": part_number},
+            ExpiresIn=PRESIGNED_URL_EXPIRY,
+        )
+        return json_response(200, {"upload_url": url})
+    except ValueError as exc:
+        return json_response(400, {"error": str(exc)})
+    except PermissionError as exc:
+        return json_response(403, {"error": str(exc)})
+    except Exception as exc:  # noqa: BLE001
+        return json_response(500, {"error": str(exc)})
+
+
+def handle_multipart_complete(event, authenticated_device=None):
+    try:
+        body, s3_key = _scoped_key(event, authenticated_device)
+        upload_id = _require(body, "upload_id")
+        raw_parts = body.get("parts") or []
+        if not raw_parts:
+            raise ValueError("parts is required")
+        parts = [
+            {"ETag": p["etag"], "PartNumber": int(p["part_number"])}
+            for p in sorted(raw_parts, key=lambda p: int(p["part_number"]))
+        ]
+        _client().complete_multipart_upload(
+            Bucket=OUTPUT_BUCKET, Key=s3_key, UploadId=upload_id, MultipartUpload={"Parts": parts}
+        )
+        return json_response(200, {"s3_key": s3_key})
+    except ValueError as exc:
+        return json_response(400, {"error": str(exc)})
+    except (KeyError, TypeError) as exc:
+        return json_response(400, {"error": f"malformed parts: {exc}"})
+    except PermissionError as exc:
+        return json_response(403, {"error": str(exc)})
+    except ClientError as exc:
+        return _gone_or_500(exc)
+    except Exception as exc:  # noqa: BLE001
+        return json_response(500, {"error": str(exc)})
+
+
+def handle_multipart_abort(event, authenticated_device=None):
+    try:
+        body, s3_key = _scoped_key(event, authenticated_device)
+        upload_id = _require(body, "upload_id")
+        _client().abort_multipart_upload(Bucket=OUTPUT_BUCKET, Key=s3_key, UploadId=upload_id)
+        return json_response(200, {"s3_key": s3_key})
+    except ValueError as exc:
+        return json_response(400, {"error": str(exc)})
+    except PermissionError as exc:
+        return json_response(403, {"error": str(exc)})
+    except ClientError as exc:
+        return _gone_or_500(exc)
+    except Exception as exc:  # noqa: BLE001
+        return json_response(500, {"error": str(exc)})

--- a/lambda/src/routes/tracks.py
+++ b/lambda/src/routes/tracks.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 import dynamodb
-from s3 import OUTPUT_BUCKET, generate_presigned_url
+from s3 import OUTPUT_BUCKET, _presign_media
 from utils import (
     DEFAULT_PAGE_LIMIT,
     HeatmapPeriod,
@@ -22,7 +22,9 @@ def _add_composite_url(item: Dict[str, object]) -> Dict[str, object]:
     normalized = dict(item)
     composite_key = normalized.get("composite_key")
     if composite_key:
-        normalized["composite_url"] = generate_presigned_url(str(composite_key), OUTPUT_BUCKET)
+        normalized["composite_url"] = _presign_media(
+            normalized, "composite_key", "composite", default_bucket=OUTPUT_BUCKET
+        )
     return normalized
 
 

--- a/lambda/src/routes/uploads.py
+++ b/lambda/src/routes/uploads.py
@@ -5,14 +5,19 @@ from s3 import OUTPUT_BUCKET, PRESIGNED_URL_EXPIRY, generate_presigned_put_url
 from utils import _parse_request, json_response
 
 
+# Hourly batch archives upload here; their members are v1 keys but the container
+# itself lives under v2/archives/<device>/<timestamp>.tar.
+ARCHIVE_PREFIX = "v2/archives/"
+
+
 def _validate_s3_key(s3_key: Any) -> str:
     if not isinstance(s3_key, str):
         raise ValueError("s3_key must be a string")
     normalized_key = s3_key.strip()
     if not normalized_key:
         raise ValueError("s3_key is required")
-    if not normalized_key.startswith("v1/"):
-        raise ValueError("s3_key must start with v1/")
+    if not (normalized_key.startswith("v1/") or normalized_key.startswith(ARCHIVE_PREFIX)):
+        raise ValueError("s3_key must start with v1/ or v2/archives/")
     if ".." in normalized_key:
         raise ValueError("s3_key cannot contain '..'")
     return normalized_key
@@ -20,6 +25,20 @@ def _validate_s3_key(s3_key: Any) -> str:
 
 def _is_manifest_key(s3_key: str) -> bool:
     return s3_key == "v1/manifest.json"
+
+
+def _key_device_id(s3_key: str) -> str:
+    """The device id is the segment after the namespace prefix:
+    v1/<device>/...  or  v2/archives/<device>/..."""
+    if s3_key.startswith(ARCHIVE_PREFIX):
+        rest = s3_key[len(ARCHIVE_PREFIX):].split("/", 1)
+        if len(rest) < 2 or not rest[0]:
+            raise PermissionError("archive s3_key must include a device prefix and object path")
+        return rest[0]
+    parts = s3_key.split("/", 2)
+    if len(parts) < 3:
+        raise PermissionError("s3_key must include a device prefix and object path")
+    return parts[1]
 
 
 def _validate_device_scope(s3_key: str, authenticated_device: Dict[str, Any]) -> None:
@@ -34,10 +53,7 @@ def _validate_device_scope(s3_key: str, authenticated_device: Dict[str, Any]) ->
     )
     allowed_devices.discard("")
 
-    if len(s3_key.split("/", 2)) < 3:
-        raise PermissionError("s3_key must include a device prefix and object path")
-
-    key_device_id = s3_key.split("/", 2)[1]
+    key_device_id = _key_device_id(s3_key)
     if key_device_id not in allowed_devices:
         raise PermissionError(f"s3_key is outside the authenticated device scope: {key_device_id}")
 

--- a/lambda/src/s3.py
+++ b/lambda/src/s3.py
@@ -48,12 +48,36 @@ def generate_presigned_put_url(
         return None
 
 
+def _presign_media(
+    item: Dict[str, Any],
+    key_field: str,
+    prefix: str,
+    default_bucket: Optional[str] = None,
+) -> Optional[str]:
+    """Presign a GET for an item's media, preferring its archive over its own key.
+
+    A row whose media was mapped into a batch tar carries archive_key/archive_bucket
+    (the intra-tar member path in `key_field` is not a real object at its own bucket)
+    -- presign the archive instead, so the caller can range-read the member out of it.
+    """
+    archive_key = item.get("archive_key")
+    archive_bucket = item.get("archive_bucket")
+    if archive_key and archive_bucket:
+        return generate_presigned_url(archive_key, archive_bucket)
+
+    key = item.get(key_field)
+    bucket = item.get(f"{prefix}_bucket", default_bucket)
+    if key and bucket:
+        return generate_presigned_url(key, bucket)
+    return None
+
+
 def _add_presigned_urls(result: Dict[str, Any]) -> Dict[str, Any]:
     for item in result.get("items", []):
         if "image_key" in item and "image_bucket" in item:
-            item["image_url"] = generate_presigned_url(item["image_key"], item["image_bucket"])
+            item["image_url"] = _presign_media(item, "image_key", "image")
         if "video_key" in item and "video_bucket" in item:
-            item["video_url"] = generate_presigned_url(item["video_key"], item["video_bucket"])
+            item["video_url"] = _presign_media(item, "video_key", "video")
     return result
 
 

--- a/tests/test_archive_video_mapping.py
+++ b/tests/test_archive_video_mapping.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+TRIGGER_SRC = Path(__file__).resolve().parents[1] / "trigger" / "src"
+sys.modules.pop("activity", None)
+sys.modules.pop("schemas", None)
+sys.modules.pop("trigger_handler", None)
+sys.path.insert(0, str(TRIGGER_SRC))
+
+import trigger_handler  # noqa: E402
+
+sys.path.remove(str(TRIGGER_SRC))
+sys.modules.pop("activity", None)
+sys.modules.pop("schemas", None)
+
+
+BUCKET = "bucket-1"
+ARCHIVE_KEY = "v2/archives/FLIK4/20260625_150000.tar"
+
+
+def _make_tar(members: dict[str, bytes]) -> bytes:
+    """Uncompressed tar so each member's byte range is valid in the raw archive."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, body in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(body)
+            tar.addfile(info, io.BytesIO(body))
+    return buf.getvalue()
+
+
+class _ArchiveStorage:
+    """Serves the archive bytes for read_bytes; empty S3 fallback for everything else."""
+
+    def __init__(self, archive_bytes: bytes) -> None:
+        self._archive_bytes = archive_bytes
+        self.objects: dict[str, bytes] = {}
+
+    def read_bytes(self, bucket: str, key: str) -> bytes:
+        return self._archive_bytes
+
+    def read_text(self, bucket, key, *, version_id=None, etag=None) -> str:
+        return self.objects[key].decode("utf-8")
+
+    def read_json(self, bucket, key, *, version_id=None, etag=None):
+        return json.loads(self.read_text(bucket, key))
+
+    def write_bytes(self, bucket, key, body, content_type) -> None:
+        self.objects[key] = body
+
+    def exists(self, bucket, key) -> bool:
+        return key in self.objects
+
+    def list_keys(self, bucket, prefix, suffix="") -> list[str]:
+        return sorted(k for k in self.objects if k.startswith(prefix) and k.endswith(suffix))
+
+
+def _process(members: dict[str, bytes]):
+    archive_bytes = _make_tar(members)
+    storage = _ArchiveStorage(archive_bytes)
+    writer = trigger_handler.CollectingWriter()
+    summary = trigger_handler.process_archive_object(storage, writer, BUCKET, ARCHIVE_KEY)
+    return archive_bytes, writer, summary
+
+
+# --- E6: the name derivation must equal the device's video_timestamp derivation ---
+
+def test_standalone_video_identity_matches_device_derivation():
+    dev, ts, prefix = trigger_handler._standalone_video_identity(
+        "v1/FLIK4/20260625_141636/video.mp4"
+    )
+    assert dev == "FLIK4"
+    assert ts == "2026-06-25T14:16:36"  # strptime("20260625_141636", "%Y%m%d_%H%M%S").isoformat()
+    assert prefix == "v1/FLIK4/20260625_141636"
+
+
+def test_standalone_video_identity_dot_layout_and_dropped_micros():
+    # DOT videos live under a videos/ subdir; the capture dir still owns the timestamp.
+    dev, ts, prefix = trigger_handler._standalone_video_identity(
+        "v1/DOT9/20260625_141636/videos/clip.mp4"
+    )
+    assert (dev, ts, prefix) == ("DOT9", "2026-06-25T14:16:36", "v1/DOT9/20260625_141636")
+    # microseconds in the capture stem are dropped, exactly as the device does.
+    _, ts_micros, _ = trigger_handler._standalone_video_identity(
+        "v1/FLIK4/20260625_141636_427099/video.mp4"
+    )
+    assert ts_micros == "2026-06-25T14:16:36"
+
+
+# --- E1 (spec's failable test): a video-only archive still maps the video ---
+
+def test_archive_video_only_member_is_mapped():
+    video_bytes = b"\x00\x01FAKE-MP4-PAYLOAD\x02\x03"
+    key = "v1/FLIK4/20260625_141636/video.mp4"
+    archive_bytes, writer, summary = _process({key: video_bytes})
+
+    assert len(writer.videos) == 1
+    row = writer.videos[0]
+    assert row["device_id"] == "FLIK4"
+    assert row["timestamp"] == "2026-06-25T14:16:36"
+    assert row["video_key"] == key
+    assert row["video_bucket"] == BUCKET
+    assert row["archive_bucket"] == BUCKET
+    assert row["archive_key"] == ARCHIVE_KEY
+    off, size = row["video_offset"], row["video_size"]
+    assert archive_bytes[off:off + size] == video_bytes
+    assert summary["videos"] == 1
+
+
+# --- E3: co-located results.json + video -> one enriched row, no duplicate ---
+
+def test_archive_colocated_results_video_is_single_enriched_row():
+    prefix = "v1/FLIK4/20260625_141636"
+    video_bytes = b"CO-LOCATED-MP4"
+    results = {
+        "source_device": "FLIK4",
+        "video_file": "video.mp4",
+        "video_timestamp": "2026-06-25T14:16:36",
+        "video_info": {"fps": 30, "total_frames": 300, "duration_seconds": 10.0},
+        "tracks": [],
+    }
+    members = {
+        f"{prefix}/video.mp4": video_bytes,
+        f"{prefix}/results.json": json.dumps(results).encode("utf-8"),
+    }
+    archive_bytes, writer, summary = _process(members)
+
+    assert len(writer.videos) == 1  # not duplicated by the standalone pass
+    row = writer.videos[0]
+    assert row["timestamp"] == "2026-06-25T14:16:36"
+    assert row["fps"] == 30  # enriched from results.json
+    off, size = row["video_offset"], row["video_size"]
+    assert archive_bytes[off:off + size] == video_bytes  # still byte-range mapped
+
+
+# --- an undecodable capture stem is skipped, not fatal ---
+
+def test_archive_video_with_underivable_timestamp_is_skipped():
+    # Capture segment lacks a HHMMSS group -> cannot match the device derivation.
+    key = "v1/DOTX/20260625/videos/clip.mp4"
+    _archive, writer, summary = _process({key: b"x"})
+    assert writer.videos == []
+    assert summary["skipped_members"] == 1

--- a/tests/test_archive_video_mapping.py
+++ b/tests/test_archive_video_mapping.py
@@ -143,6 +143,31 @@ def test_archive_colocated_results_video_is_single_enriched_row():
     assert archive_bytes[off:off + size] == video_bytes  # still byte-range mapped
 
 
+# --- results.json referencing a FLAT (un-archived) video: row served from flat key ---
+
+def test_archive_results_referencing_flat_video_stays_unstamped():
+    prefix = "v1/FLIK4/20260625_141636"
+    results = {
+        "source_device": "FLIK4",
+        "video_file": "orig.mp4",
+        "video_timestamp": "2026-06-25T14:16:36",
+        "video_info": {"fps": 30, "total_frames": 300, "duration_seconds": 10.0},
+        "tracks": [],
+    }
+    # results.json is in the tar; the video is NOT a member -- it lives flat in S3.
+    archive_bytes = _make_tar({f"{prefix}/results.json": json.dumps(results).encode("utf-8")})
+    storage = _ArchiveStorage(archive_bytes)
+    storage.objects[f"{prefix}/orig.mp4"] = b"FLAT-S3-VIDEO"  # flat fallback object
+    writer = trigger_handler.CollectingWriter()
+    summary = trigger_handler.process_archive_object(storage, writer, BUCKET, ARCHIVE_KEY)
+
+    assert len(writer.videos) == 1
+    row = writer.videos[0]
+    assert row["video_key"] == f"{prefix}/orig.mp4"
+    assert "archive_key" not in row and "video_offset" not in row  # unstamped -> serves flat
+    assert summary["videos"] == 1
+
+
 # --- an undecodable capture stem is skipped, not fatal ---
 
 def test_archive_video_with_underivable_timestamp_is_skipped():

--- a/tests/test_archive_video_mapping.py
+++ b/tests/test_archive_video_mapping.py
@@ -208,3 +208,30 @@ def test_process_video_object_underivable_timestamp_is_skipped_not_fatal():
 
     assert writer.videos == []
     assert summary["videos"] == 0
+
+
+# --- a DOT camera's flat upload: the capture dir is a per-day folder (date only,
+# no HHMMSS), but the filename itself carries <device>_<date>_<time>_<track>. The
+# device stamped video_timestamp from the filename, so ingest must too. Real-world
+# key from the 2026-07-03 FLIK4-dot05 field test (SG classification-gap report). ---
+
+def test_standalone_video_identity_dot_flat_upload_falls_back_to_filename_timestamp():
+    dev, ts, prefix = trigger_handler._standalone_video_identity(
+        "v1/FLIK4-dot05/20260703/videos/FLIK4-dot05_20260703_011737_f78510c7.mp4"
+    )
+    assert dev == "FLIK4-dot05"
+    assert ts == "2026-07-03T01:17:37"
+    assert prefix == "v1/FLIK4-dot05/20260703"
+
+
+def test_process_video_object_dot_flat_upload_is_mapped_via_filename_fallback():
+    key = "v1/FLIK4-dot05/20260703/videos/FLIK4-dot05_20260703_011737_f78510c7.mp4"
+    writer = trigger_handler.CollectingWriter()
+    summary = trigger_handler.process_video_object(_ArchiveStorage(b""), writer, BUCKET, key)
+
+    assert len(writer.videos) == 1
+    row = writer.videos[0]
+    assert row["device_id"] == "FLIK4-dot05"
+    assert row["timestamp"] == "2026-07-03T01:17:37"
+    assert row["video_key"] == key
+    assert summary["videos"] == 1

--- a/tests/test_archive_video_mapping.py
+++ b/tests/test_archive_video_mapping.py
@@ -176,3 +176,35 @@ def test_archive_video_with_underivable_timestamp_is_skipped():
     _archive, writer, summary = _process({key: b"x"})
     assert writer.videos == []
     assert summary["skipped_members"] == 1
+
+
+# --- a video uploaded flat (outside any archive) is still mapped, not ignored ---
+
+def test_flat_video_upload_is_classified_as_video_not_ignored():
+    key = "v1/FLIK4/20260625_141636/video.mp4"
+    assert trigger_handler._processing_kind(key) == trigger_handler.ProcessingKind.VIDEO
+
+
+def test_process_video_object_maps_flat_video_to_device_and_timestamp():
+    key = "v1/FLIK4/20260625_141636/video.mp4"
+    writer = trigger_handler.CollectingWriter()
+    summary = trigger_handler.process_video_object(_ArchiveStorage(b""), writer, BUCKET, key)
+
+    assert len(writer.videos) == 1
+    row = writer.videos[0]
+    assert row["device_id"] == "FLIK4"
+    assert row["timestamp"] == "2026-06-25T14:16:36"
+    assert row["video_key"] == key
+    assert row["video_bucket"] == BUCKET
+    assert "archive_key" not in row  # flat, not archived -- no byte-range stamp
+    assert row.get("fps") is None  # bare row: differentiable from a results-associated video
+    assert summary["videos"] == 1
+
+
+def test_process_video_object_underivable_timestamp_is_skipped_not_fatal():
+    key = "v1/DOTX/20260625/videos/clip.mp4"
+    writer = trigger_handler.CollectingWriter()
+    summary = trigger_handler.process_video_object(_ArchiveStorage(b""), writer, BUCKET, key)
+
+    assert writer.videos == []
+    assert summary["videos"] == 0

--- a/tests/test_handler_routes_and_auth.py
+++ b/tests/test_handler_routes_and_auth.py
@@ -1,5 +1,6 @@
 import json
 
+import s3
 from auth import validate_api_key
 import handler
 
@@ -476,7 +477,7 @@ def test_handle_get_track_adds_composite_url(monkeypatch):
             "composite_key": "outputs/track-1.jpg",
         },
     )
-    monkeypatch.setattr(handler.tracks, "generate_presigned_url", lambda key, bucket: f"{bucket}/{key}")
+    monkeypatch.setattr(s3, "generate_presigned_url", lambda key, bucket=None, expiration=s3.PRESIGNED_URL_EXPIRY: f"{bucket}/{key}")
 
     response = handler.tracks.handle_get_single(_http_event("GET", "/tracks/track-1"), "track-1")
 

--- a/tests/test_media_presign.py
+++ b/tests/test_media_presign.py
@@ -1,0 +1,133 @@
+import os
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+import pytest
+
+import s3
+from routes import tracks
+
+
+@pytest.fixture
+def recorded_presigns(monkeypatch):
+    """Patches s3.generate_presigned_url and records (key, bucket) call args.
+
+    tracks.py imports the same function by reference (`from s3 import _presign_media`
+    -> `generate_presigned_url`), so patching the s3 module's global is sufficient for
+    both call sites: the lookup happens inside s3.py at call time either way.
+    """
+    calls = []
+
+    def fake(key, bucket=None, expiration=s3.PRESIGNED_URL_EXPIRY):
+        calls.append((key, bucket))
+        return f"https://example.invalid/{bucket}/{key}"
+
+    monkeypatch.setattr(s3, "generate_presigned_url", fake)
+    return calls
+
+
+def test_add_presigned_urls_uses_archive_for_stamped_video_row(recorded_presigns):
+    """An archived row's video_key is a path inside the tar, not a real object at
+    video_bucket -- the presign target must be the archive, not the member path."""
+    item = {
+        "video_key": "v1/FLIK4/20260625_141636/video.mp4",
+        "video_bucket": "scl-sensing-garden-videos",
+        "archive_key": "v2/archives/FLIK4/20260625_150000.tar",
+        "archive_bucket": "scl-sensing-garden",
+        "video_offset": 512,
+        "video_size": 1024,
+    }
+
+    result = s3._add_presigned_urls({"items": [item]})
+
+    assert recorded_presigns == [("v2/archives/FLIK4/20260625_150000.tar", "scl-sensing-garden")]
+    assert result["items"][0]["video_url"] == (
+        "https://example.invalid/scl-sensing-garden/v2/archives/FLIK4/20260625_150000.tar"
+    )
+    # unchanged: the stamped offset/size were already passing through untouched
+    assert result["items"][0]["video_offset"] == 512
+    assert result["items"][0]["video_size"] == 1024
+
+
+def test_add_presigned_urls_standalone_video_row_unchanged(recorded_presigns):
+    """A row with no archive fields keeps presigning its own key/bucket, exactly as
+    today -- this must not regress when the archived branch is added."""
+    item = {
+        "video_key": "v1/FLIK4/20260625_141636/video.mp4",
+        "video_bucket": "scl-sensing-garden-videos",
+    }
+
+    result = s3._add_presigned_urls({"items": [item]})
+
+    assert recorded_presigns == [("v1/FLIK4/20260625_141636/video.mp4", "scl-sensing-garden-videos")]
+    assert result["items"][0]["video_url"] == (
+        "https://example.invalid/scl-sensing-garden-videos/v1/FLIK4/20260625_141636/video.mp4"
+    )
+
+
+def test_add_presigned_urls_uses_archive_for_stamped_image_row(recorded_presigns):
+    item = {
+        "image_key": "v1/FLIK4/20260625_141636/crop_0.jpg",
+        "image_bucket": "scl-sensing-garden-images",
+        "archive_key": "v2/archives/FLIK4/20260625_150000.tar",
+        "archive_bucket": "scl-sensing-garden",
+        "image_offset": 2048,
+        "image_size": 256,
+    }
+
+    result = s3._add_presigned_urls({"items": [item]})
+
+    assert recorded_presigns == [("v2/archives/FLIK4/20260625_150000.tar", "scl-sensing-garden")]
+    assert result["items"][0]["image_url"] == (
+        "https://example.invalid/scl-sensing-garden/v2/archives/FLIK4/20260625_150000.tar"
+    )
+
+
+def test_add_composite_url_uses_archive_for_stamped_composite_row(recorded_presigns):
+    """Composites have no composite_bucket field -- they default to OUTPUT_BUCKET --
+    but an archived row must still win over that default, same as video/image."""
+    item = {
+        "composite_key": "v1/FLIK4/20260625_141636/composite_0.jpg",
+        "archive_key": "v2/archives/FLIK4/20260625_150000.tar",
+        "archive_bucket": "scl-sensing-garden",
+        "composite_offset": 4096,
+        "composite_size": 128,
+    }
+
+    result = tracks._add_composite_url(item)
+
+    assert recorded_presigns == [("v2/archives/FLIK4/20260625_150000.tar", "scl-sensing-garden")]
+    assert result["composite_url"] == (
+        "https://example.invalid/scl-sensing-garden/v2/archives/FLIK4/20260625_150000.tar"
+    )
+
+
+def test_add_composite_url_standalone_row_still_defaults_to_output_bucket(recorded_presigns):
+    item = {"composite_key": "tracks/abc123/composite.jpg"}
+
+    result = tracks._add_composite_url(item)
+
+    assert recorded_presigns == [("tracks/abc123/composite.jpg", s3.OUTPUT_BUCKET)]
+    assert result["composite_url"] == (
+        f"https://example.invalid/{s3.OUTPUT_BUCKET}/tracks/abc123/composite.jpg"
+    )
+
+
+def test_add_presigned_urls_presign_failure_returns_none_not_raise(monkeypatch):
+    def raising(key, bucket=None, expiration=s3.PRESIGNED_URL_EXPIRY):
+        raise RuntimeError("boto3 boom")
+
+    # generate_presigned_url itself already catches and returns None (s3.py) --
+    # this proves _presign_media doesn't need its own try/except on top of that.
+    monkeypatch.setattr(s3.s3, "generate_presigned_url", raising)
+
+    item = {
+        "video_key": "v1/FLIK4/20260625_141636/video.mp4",
+        "video_bucket": "scl-sensing-garden-videos",
+        "archive_key": "v2/archives/FLIK4/20260625_150000.tar",
+        "archive_bucket": "scl-sensing-garden",
+    }
+
+    result = s3._add_presigned_urls({"items": [item]})
+
+    assert result["items"][0]["video_url"] is None

--- a/trigger/src/trigger_handler.py
+++ b/trigger/src/trigger_handler.py
@@ -3,11 +3,14 @@ import logging
 import os
 import re
 import hashlib
+import posixpath
+import tarfile
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import Enum
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Protocol, Tuple
 from urllib.parse import unquote_plus
@@ -56,10 +59,37 @@ class S3TriggerAction(str, Enum):
 
 
 class ProcessingKind(str, Enum):
+    ARCHIVE = "archive"
     RESULTS = "results"
     HEARTBEAT = "heartbeat"
     ENVIRONMENT = "environment"
     IGNORED = "ignored"
+
+
+# Hourly batch archives live in the v2 namespace; their members are canonical
+# v1/ keys. In this (index) approach the media stays inside the tar and each
+# record is stamped with the tar's location plus the member's byte range, so a
+# range-reading serve path can fetch the bytes without re-exploding to S3.
+ARCHIVE_SUFFIXES = (".tar",)
+ARCHIVE_KEY_PREFIX = "v2/archives/"
+
+# Device-local sidecars that are never bundled / processed.
+ARCHIVE_SKIP_NAMES = frozenset(
+    {".done", ".detection.json", ".expected_tracks", ".completed_tracks", ".uploaded", ".archived", ".archived-aux"}
+)
+
+
+def _is_safe_archive_member(name: str) -> bool:
+    """Reject anything that is not a canonical v1/ key or that path-traverses."""
+    if not name or name.startswith("/"):
+        return False
+    if not name.startswith("v1/"):
+        return False
+    if posixpath.normpath(name) != name or ".." in name.split("/"):
+        return False
+    if Path(name).name in ARCHIVE_SKIP_NAMES:
+        return False
+    return True
 
 
 class ProcessedObjectStatus(str, Enum):
@@ -233,6 +263,57 @@ class LocalStorageAdapter(StorageAdapter):
                 if not suffix or rel.endswith(suffix):
                     keys.append(rel)
         return sorted(keys)
+
+
+class TarStorageAdapter(StorageAdapter):
+    """Reads from an in-memory (uncompressed) tar; falls back to S3 for non-members.
+
+    The archive is uncompressed, so each member's ``offset_data`` and ``size`` are
+    byte offsets into the raw archive bytes -- exposed via :meth:`member_range` so
+    records can carry a range a serve path can fetch with a single ranged GET.
+    Reads for keys not in the tar (notably ``v1/manifest.json``) defer to S3.
+    Generated artifacts (composites the device did not supply) are written through
+    to S3, since they cannot be added to the immutable archive.
+    """
+
+    def __init__(self, archive_bytes: bytes, fallback: StorageAdapter) -> None:
+        self._archive_bytes = archive_bytes
+        self._fallback = fallback
+        self._ranges: Dict[str, Tuple[int, int]] = {}
+        with tarfile.open(fileobj=BytesIO(archive_bytes), mode="r:") as tar:
+            for member in tar.getmembers():
+                if member.isfile() and _is_safe_archive_member(member.name):
+                    self._ranges[member.name] = (member.offset_data, member.size)
+
+    def member_names(self) -> List[str]:
+        return list(self._ranges)
+
+    def member_range(self, key: str) -> Optional[Tuple[int, int]]:
+        return self._ranges.get(key)
+
+    def _member_bytes(self, key: str) -> bytes:
+        offset, size = self._ranges[key]
+        return self._archive_bytes[offset:offset + size]
+
+    def read_text(self, bucket, key, *, version_id=None, etag=None) -> str:
+        if key in self._ranges:
+            return self._member_bytes(key).decode("utf-8")
+        return self._fallback.read_text(bucket, key, version_id=version_id, etag=etag)
+
+    def read_bytes(self, bucket: str, key: str) -> bytes:
+        if key in self._ranges:
+            return self._member_bytes(key)
+        return self._fallback.read_bytes(bucket, key)
+
+    def write_bytes(self, bucket: str, key: str, body: bytes, content_type: str) -> None:
+        self._fallback.write_bytes(bucket, key, body, content_type)
+
+    def exists(self, bucket: str, key: str) -> bool:
+        return key in self._ranges or self._fallback.exists(bucket, key)
+
+    def list_keys(self, bucket: str, prefix: str, suffix: str = "") -> List[str]:
+        members = [k for k in self._ranges if k.startswith(prefix) and (not suffix or k.endswith(suffix))]
+        return sorted(set(members) | set(self._fallback.list_keys(bucket, prefix, suffix)))
 
 
 class DynamoWriter:
@@ -419,6 +500,55 @@ class CollectingWriter:
 
     def put_environmental_readings(self, items: List[Dict[str, Any]]) -> None:
         self.environmental_readings.extend(items)
+
+
+class ArchiveIndexWriter:
+    """Wraps a writer and stamps each record with the archive + byte range of its
+    media, so serving can range-read the tar instead of fetching a standalone key.
+
+    A record whose media is not a tar member (e.g. a composite generated server
+    side and written to S3) is left unstamped and serves from its flat key.
+    """
+
+    def __init__(self, inner: "WriterProtocol", adapter: TarStorageAdapter, bucket: str, archive_key: str) -> None:
+        self._inner = inner
+        self._adapter = adapter
+        self._bucket = bucket
+        self._archive_key = archive_key
+
+    def _stamp(self, item: Dict[str, Any], key_field: str, prefix: str) -> None:
+        member_range = self._adapter.member_range(item.get(key_field))
+        if member_range is None:
+            return
+        offset, size = member_range
+        item["archive_bucket"] = self._bucket
+        item["archive_key"] = self._archive_key
+        item[f"{prefix}_offset"] = offset
+        item[f"{prefix}_size"] = size
+
+    def put_tracks(self, items: List[Dict[str, Any]]) -> None:
+        for item in items:
+            self._stamp(item, "composite_key", "composite")
+        self._inner.put_tracks(items)
+
+    def put_classifications(self, items: List[Dict[str, Any]]) -> None:
+        for item in items:
+            self._stamp(item, "image_key", "image")
+        self._inner.put_classifications(items)
+
+    def put_videos(self, items: List[Dict[str, Any]]) -> None:
+        for item in items:
+            self._stamp(item, "video_key", "video")
+        self._inner.put_videos(items)
+
+    def put_devices_if_missing(self, items: List[Dict[str, Any]]) -> None:
+        self._inner.put_devices_if_missing(items)
+
+    def put_heartbeats(self, items: List[Dict[str, Any]]) -> None:
+        self._inner.put_heartbeats(items)
+
+    def put_environmental_readings(self, items: List[Dict[str, Any]]) -> None:
+        self._inner.put_environmental_readings(items)
 
 
 class WriterProtocol(Protocol):
@@ -906,6 +1036,70 @@ def process_environment_object(
     return {"environmental_readings": 1}
 
 
+def _merge_summary(total: Dict[str, int], part: Dict[str, int]) -> None:
+    for key, value in part.items():
+        if isinstance(value, (int, float)):
+            total[key] = total.get(key, 0) + value
+
+
+def process_archive_object(
+    storage: StorageAdapter,
+    writer: WriterProtocol,
+    bucket: str,
+    key: str,
+    *,
+    version_id: Optional[str] = None,
+    etag: Optional[str] = None,
+) -> Dict[str, int]:
+    """Index an hourly batch tar in place: process its members without exploding.
+
+    The media stays inside the archive; a tar-backed StorageAdapter feeds the
+    existing per-object processors so the same DynamoDB rows are written, and an
+    ArchiveIndexWriter stamps each row with the archive location + the member's
+    byte range so serving can range-read. A single idempotency claim covers the
+    whole archive (see process_s3_object); inner writes are deterministic upserts.
+    """
+    archive_bytes = storage.read_bytes(bucket, key)
+    adapter = TarStorageAdapter(archive_bytes, storage)
+    index_writer = ArchiveIndexWriter(writer, adapter, bucket, key)
+
+    summary: Dict[str, int] = {"archives": 1, "result_objects": 0, "skipped_members": 0}
+    results_names: List[str] = []
+    json_object_names: List[str] = []
+    for name in adapter.member_names():
+        if name.endswith("/results.json"):
+            results_names.append(name)
+        elif _processing_kind(name) in (ProcessingKind.HEARTBEAT, ProcessingKind.ENVIRONMENT):
+            json_object_names.append(name)
+
+    for name in sorted(results_names):
+        try:
+            _merge_summary(summary, process_results_object(adapter, index_writer, bucket, name))
+            summary["result_objects"] += 1
+        except Exception as exc:
+            summary["skipped_members"] += 1
+            log_s3_trigger(
+                S3TriggerAction.FAILED, bucket, name, kind=ProcessingKind.RESULTS.value,
+                reason="archive_member_failed", archive_key=key, error=str(exc),
+            )
+
+    for name in sorted(json_object_names):
+        member_kind = _processing_kind(name)
+        try:
+            if member_kind == ProcessingKind.HEARTBEAT:
+                _merge_summary(summary, process_heartbeat_object(adapter, index_writer, bucket, name))
+            else:
+                _merge_summary(summary, process_environment_object(adapter, index_writer, bucket, name))
+        except Exception as exc:
+            summary["skipped_members"] += 1
+            log_s3_trigger(
+                S3TriggerAction.FAILED, bucket, name, kind=member_kind.value,
+                reason="archive_member_failed", archive_key=key, error=str(exc),
+            )
+
+    return summary
+
+
 def parse_s3_event(event: Dict[str, Any]) -> List[S3ObjectEvent]:
     records: List[S3ObjectEvent] = []
     for record in event.get("Records", []):
@@ -937,6 +1131,8 @@ def _processing_status(summary: Dict[str, int]) -> str:
 
 
 def _processing_kind(key: str) -> ProcessingKind:
+    if key.startswith(ARCHIVE_KEY_PREFIX) and key.endswith(ARCHIVE_SUFFIXES):
+        return ProcessingKind.ARCHIVE
     if key.endswith("/results.json"):
         return ProcessingKind.RESULTS
     if HEARTBEAT_KEY_PATTERN.match(key):
@@ -997,7 +1193,8 @@ def process_s3_object(
 ) -> Dict[str, int]:
     kind = _processing_kind(event.key)
     log_s3_trigger(S3TriggerAction.RECEIVED, event.bucket, event.key, kind=kind.value)
-    if not event.key.startswith("v1/"):
+    # Archives are the one supported object outside v1/: their members are v1 keys.
+    if kind != ProcessingKind.ARCHIVE and not event.key.startswith("v1/"):
         log_s3_trigger(S3TriggerAction.IGNORED, event.bucket, event.key, reason="outside_v1_prefix")
         activity.record_object_ignored(event.bucket, event.key, activity.TriggerFailureReason.OUTSIDE_V1_PREFIX)
         return {}
@@ -1018,7 +1215,16 @@ def process_s3_object(
     try:
         activity.record_s3_received(event.bucket, event.key, kind.value)
         log_s3_trigger(S3TriggerAction.PROCESSING, event.bucket, event.key, kind=kind.value)
-        if kind == ProcessingKind.RESULTS:
+        if kind == ProcessingKind.ARCHIVE:
+            summary = process_archive_object(
+                storage,
+                writer,
+                event.bucket,
+                event.key,
+                version_id=event.version_id,
+                etag=event.etag,
+            )
+        elif kind == ProcessingKind.RESULTS:
             summary = process_results_object(
                 storage,
                 writer,

--- a/trigger/src/trigger_handler.py
+++ b/trigger/src/trigger_handler.py
@@ -63,6 +63,7 @@ class ProcessingKind(str, Enum):
     RESULTS = "results"
     HEARTBEAT = "heartbeat"
     ENVIRONMENT = "environment"
+    VIDEO = "video"
     IGNORED = "ignored"
 
 
@@ -1081,6 +1082,28 @@ def process_environment_object(
     return {"environmental_readings": 1}
 
 
+def process_video_object(
+    storage: StorageAdapter,
+    writer: WriterProtocol,
+    bucket: str,
+    key: str,
+    *,
+    version_id: Optional[str] = None,
+    etag: Optional[str] = None,
+) -> Dict[str, int]:
+    """A video uploaded flat (outside any archive) still gets a name-derived row,
+    same identity derivation as an archived standalone video (_build_standalone_video_record)
+    -- it just has no archive_key/byte-range stamp, so it serves from its flat key."""
+    try:
+        video_record = _build_standalone_video_record(bucket, key)
+    except ValueError as exc:
+        print(f"Video identity derivation failed for {key}: {exc}")
+        return {"videos": 0}
+    writer.put_videos([video_record])
+    print(f"Processed 1 video from {key}")
+    return {"videos": 1}
+
+
 def _merge_summary(total: Dict[str, int], part: Dict[str, int]) -> None:
     for key, value in part.items():
         if isinstance(value, (int, float)):
@@ -1203,6 +1226,8 @@ def _processing_kind(key: str) -> ProcessingKind:
         return ProcessingKind.HEARTBEAT
     if ENVIRONMENT_KEY_PATTERN.match(key):
         return ProcessingKind.ENVIRONMENT
+    if key.endswith(VIDEO_MEMBER_SUFFIX):
+        return ProcessingKind.VIDEO
     return ProcessingKind.IGNORED
 
 
@@ -1299,6 +1324,15 @@ def process_s3_object(
             )
         elif kind == ProcessingKind.HEARTBEAT:
             summary = process_heartbeat_object(
+                storage,
+                writer,
+                event.bucket,
+                event.key,
+                version_id=event.version_id,
+                etag=event.etag,
+            )
+        elif kind == ProcessingKind.VIDEO:
+            summary = process_video_object(
                 storage,
                 writer,
                 event.bucket,

--- a/trigger/src/trigger_handler.py
+++ b/trigger/src/trigger_handler.py
@@ -351,11 +351,11 @@ class ProcessedObjectStore:
         self.table.update_item(
             Key={"object_id": object_id},
             UpdateExpression=(
-                "SET #status = :processed, ttl = :ttl, updated_at = :now "
+                "SET #status = :processed, #ttl = :ttl, updated_at = :now "
                 "REMOVE lease_until, attempt_id"
             ),
             ConditionExpression="#status = :processing AND attempt_id = :attempt_id",
-            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeNames={"#status": "status", "#ttl": "ttl"},
             ExpressionAttributeValues={
                 ":processing": ProcessedObjectStatus.PROCESSING.value,
                 ":processed": ProcessedObjectStatus.PROCESSED.value,

--- a/trigger/src/trigger_handler.py
+++ b/trigger/src/trigger_handler.py
@@ -73,6 +73,11 @@ class ProcessingKind(str, Enum):
 ARCHIVE_SUFFIXES = (".tar",)
 ARCHIVE_KEY_PREFIX = "v2/archives/"
 
+# Video members are indexed on their own (not only via a co-located results.json),
+# so a video that lands in an archive without its results -- a sampled video with no
+# detections, a DOT video, or a capture split across archives -- is still mapped.
+VIDEO_MEMBER_SUFFIX = ".mp4"
+
 # Device-local sidecars that are never bundled / processed.
 ARCHIVE_SKIP_NAMES = frozenset(
     {".done", ".detection.json", ".expected_tracks", ".completed_tracks", ".uploaded", ".archived", ".archived-aux"}
@@ -515,6 +520,9 @@ class ArchiveIndexWriter:
         self._adapter = adapter
         self._bucket = bucket
         self._archive_key = archive_key
+        # video_keys already emitted (via a results.json), so the standalone-video
+        # pass can skip them and avoid writing a duplicate/less-complete row.
+        self.seen_video_keys: set = set()
 
     def _stamp(self, item: Dict[str, Any], key_field: str, prefix: str) -> None:
         member_range = self._adapter.member_range(item.get(key_field))
@@ -539,6 +547,9 @@ class ArchiveIndexWriter:
     def put_videos(self, items: List[Dict[str, Any]]) -> None:
         for item in items:
             self._stamp(item, "video_key", "video")
+            video_key = item.get("video_key")
+            if video_key is not None:
+                self.seen_video_keys.add(video_key)
         self._inner.put_videos(items)
 
     def put_devices_if_missing(self, items: List[Dict[str, Any]]) -> None:
@@ -859,6 +870,40 @@ def _build_video_records(
     return [_model_dump(record)]
 
 
+def _standalone_video_identity(video_key: str) -> Tuple[str, str, str]:
+    """(device_id, timestamp, s3_prefix) for a video member, from its key alone.
+
+    The capture directory is named after the video's stem; the device derives a
+    video's ``video_timestamp`` from that same stem's first two underscore groups
+    (``YYYYMMDD_HHMMSS``, microseconds dropped -- bugcam edge26 ``main.py``). We
+    reproduce that exactly so a co-located ``results.json`` (which serves its
+    ``video_timestamp``) enriches the same ``(device_id, timestamp)`` row instead
+    of creating a second one.
+    """
+    prefix = video_key.rsplit("/", 1)[0]
+    if prefix.rsplit("/", 1)[-1] == "videos":  # DOT layout: <capture>/videos/<file>.mp4
+        prefix = prefix.rsplit("/", 1)[0]
+    head, _, capture = prefix.rpartition("/")
+    device_id = head.rsplit("/", 1)[-1]
+    stem = capture.split("_")
+    if not device_id or len(stem) < 2:
+        raise ValueError(f"cannot derive video identity from key: {video_key!r}")
+    timestamp = datetime.strptime(f"{stem[0]}_{stem[1]}", "%Y%m%d_%H%M%S").isoformat()
+    return device_id, timestamp, prefix
+
+
+def _build_standalone_video_record(bucket: str, video_key: str) -> Dict[str, Any]:
+    device_id, timestamp, prefix = _standalone_video_identity(video_key)
+    record = Video(
+        device_id=device_id,
+        timestamp=timestamp,
+        video_key=video_key,
+        video_bucket=bucket,
+        s3_prefix=prefix,
+    )
+    return _model_dump(record)
+
+
 def _parse_and_build_records(
     storage: StorageAdapter,
     bucket: str,
@@ -1066,9 +1111,12 @@ def process_archive_object(
     summary: Dict[str, int] = {"archives": 1, "result_objects": 0, "skipped_members": 0}
     results_names: List[str] = []
     json_object_names: List[str] = []
+    video_names: List[str] = []
     for name in adapter.member_names():
         if name.endswith("/results.json"):
             results_names.append(name)
+        elif name.endswith(VIDEO_MEMBER_SUFFIX):
+            video_names.append(name)
         elif _processing_kind(name) in (ProcessingKind.HEARTBEAT, ProcessingKind.ENVIRONMENT):
             json_object_names.append(name)
 
@@ -1080,6 +1128,22 @@ def process_archive_object(
             summary["skipped_members"] += 1
             log_s3_trigger(
                 S3TriggerAction.FAILED, bucket, name, kind=ProcessingKind.RESULTS.value,
+                reason="archive_member_failed", archive_key=key, error=str(exc),
+            )
+
+    # Standalone videos: any .mp4 a results.json above did not already emit. results
+    # run first, so seen_video_keys covers co-located videos; the leftovers get a
+    # name-derived, byte-range-stamped row here so every archived video is served.
+    for name in sorted(video_names):
+        if name in index_writer.seen_video_keys:
+            continue
+        try:
+            index_writer.put_videos([_build_standalone_video_record(bucket, name)])
+            summary["videos"] = summary.get("videos", 0) + 1
+        except Exception as exc:
+            summary["skipped_members"] += 1
+            log_s3_trigger(
+                S3TriggerAction.FAILED, bucket, name, kind="video",
                 reason="archive_member_failed", archive_key=key, error=str(exc),
             )
 

--- a/trigger/src/trigger_handler.py
+++ b/trigger/src/trigger_handler.py
@@ -880,6 +880,12 @@ def _standalone_video_identity(video_key: str) -> Tuple[str, str, str]:
     reproduce that exactly so a co-located ``results.json`` (which serves its
     ``video_timestamp``) enriches the same ``(device_id, timestamp)`` row instead
     of creating a second one.
+
+    A DOT camera's flat upload breaks that assumption: its capture dir is a
+    per-day folder (date only, no ``HHMMSS``), because ``videos/`` sits directly
+    under ``<device>/<date>/`` rather than under a per-clip capture dir. The
+    filename itself still carries ``<device>_<date>_<time>_...``, so fall back to
+    parsing that when the capture dir alone doesn't decode.
     """
     prefix = video_key.rsplit("/", 1)[0]
     if prefix.rsplit("/", 1)[-1] == "videos":  # DOT layout: <capture>/videos/<file>.mp4
@@ -887,7 +893,14 @@ def _standalone_video_identity(video_key: str) -> Tuple[str, str, str]:
     head, _, capture = prefix.rpartition("/")
     device_id = head.rsplit("/", 1)[-1]
     stem = capture.split("_")
-    if not device_id or len(stem) < 2:
+    if not device_id:
+        raise ValueError(f"cannot derive video identity from key: {video_key!r}")
+    if len(stem) < 2:
+        filename = video_key.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        parts = filename.split("_")
+        if len(parts) >= 3 and parts[0] == device_id:
+            stem = parts[1:]
+    if len(stem) < 2:
         raise ValueError(f"cannot derive video identity from key: {video_key!r}")
     timestamp = datetime.strptime(f"{stem[0]}_{stem[1]}", "%Y%m%d_%H%M%S").isoformat()
     return device_id, timestamp, prefix


### PR DESCRIPTION
- Added support for multipart requests.
- Configure trigger to handle archives on v2 path. Archives have their objects mapped, the mapping is stored in the DB. When accessing objects via the api, that mapping can be used alongside the presigned s3 GET url. All tables previously populated by normal files should still be populated as expected.
- Index all uploaded videos. 